### PR TITLE
Update to ubuntu 14.04 and Miniconda 3.7.0

### DIFF
--- a/omero-conda/Dockerfile
+++ b/omero-conda/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN apt-get update && apt-get install -y bzip2 unzip wget openjdk-7-jre-headless
@@ -6,15 +6,12 @@ RUN apt-get update && apt-get install -y bzip2 unzip wget openjdk-7-jre-headless
 RUN useradd -m omero
 
 RUN cd /tmp && \
-    wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh && \
-    /bin/bash Miniconda-3.4.2-Linux-x86_64.sh -b -p /opt/anaconda && \
-    rm Miniconda-3.4.2-Linux-x86_64.sh
+    wget http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh && \
+    /bin/bash Miniconda-3.7.0-Linux-x86_64.sh -b -p /opt/anaconda && \
+    rm Miniconda-3.7.0-Linux-x86_64.sh
 
-RUN /opt/anaconda/bin/conda install --yes numpy && \
-    /opt/anaconda/bin/conda install --yes scipy && \
-    /opt/anaconda/bin/conda install --yes matplotlib && \
-    /opt/anaconda/bin/conda install --yes ipython && \
-    /opt/anaconda/bin/conda install --yes pytables
+RUN /opt/anaconda/bin/conda install --yes \
+	numpy scipy matplotlib ipython pytables
 
 RUN echo 'export PATH=/opt/anaconda/bin:$PATH' >> .bashrc
 


### PR DESCRIPTION
@joshmoore I remember you saying there was a reason you couldn't use 14.04, though I can't remember what it was and this seems to be working:

```
$ wget https://downloads.openmicroscopy.org/omero/5.0.6/artifacts/OMERO.py-5.0.6-ice35-b53.zip
$ unzip OMERO.py-5.0.6-ice35-b53.zip
$ $ OMERO.py-5.0.6-ice35-b53//bin/omero shell --login
Server: [localhost]octopus
Username: [omero]user-1
Password:
Created session 11b0ea18-f579-4a37-9442-28c60e456aa3 (user-1@octopus:4064). Idle timeout: 10.0 min. Current group: private-1
Python 2.7.9 |Continuum Analytics, Inc.| (default, Dec 15 2014, 10:33:51)
Type "copyright", "credits" or "license" for more information.

IPython 2.3.1 -- An enhanced Interactive Python.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.
```